### PR TITLE
fix: on providing wrong Id to delete note, it pops an error

### DIFF
--- a/utils/notes-utility.js
+++ b/utils/notes-utility.js
@@ -90,11 +90,15 @@ const delete_note = (id) => {
           err.push({ error: `Note with id ${id} is already deleted` });
           return;
         }
+        mess.push({ message: `Note with Id ${id} found!.` });
         element.status = "deleted";
         return;
       }
     });
-    if (err.length == 0) {
+    if (err.length == 0 && mess.length == 0) {
+      err.push({ error: `Note with ID ${id} not found.` });
+    }
+    else if(mess.length > 0){
       writeFile(file_content);
     }
     return { err, mess };


### PR DESCRIPTION
#11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feedback when deleting notes by providing clear success or error messages, distinguishing between "note not found" and "note already deleted" scenarios.
  - Ensured file updates only occur when a note is actually marked as deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->