### PR TITLE
fix: fixed the error thrown where there is no notes to display on ls-…

### DIFF
--- a/utils/notes-utility.js
+++ b/utils/notes-utility.js
@@ -51,8 +51,8 @@ const list_notes = (tags, sort) => {
   var res = file_content.filter((item) => item.status === "live");
   try {
     if (file_content.length == 0) {
-      err.push({ error: "No notes to display" });
-      return { err, mess };
+      mess.push({ message: "No notes to display" });
+      return { err, mess, res };
     }
     if (tags && tags.length > 0) {
       res = res.filter(


### PR DESCRIPTION
…notes

successful merge will close #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty notes by displaying an informational message ("No notes to display") instead of an error when no notes exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->